### PR TITLE
Add SGD optimizer with CUDA support

### DIFF
--- a/examples/run_sgd.py
+++ b/examples/run_sgd.py
@@ -1,0 +1,83 @@
+"""SGD 优化示例，与 ``run_evolution.py`` 参数一致"""
+
+import numpy as np
+from opt_sim.components import (
+    tunable_mzi_in,
+    tunable_mzi_out,
+    phase_shifter_matrix,
+)
+from opt_sim.reference import create_reference_box_filter
+from opt_sim.simulation import optical_simulation
+from opt_sim.optimization import optimize_params_sgd
+
+
+if __name__ == "__main__":
+    n_ku = 3
+    m_kl = 2
+
+    f_center = 193.1e12
+    fsr = 100e9
+    s = 10
+    t = 0.979888
+
+    theta_i = np.pi / 2
+    theta_o = np.pi / 2
+    phi_t = 0.0
+    phi_b = 0.0
+
+    w1 = -20 * np.pi
+    w2 = 20 * np.pi
+    dw = 0.006285
+    w_range = np.arange(w1, w2, dw)
+    len_w = len(w_range)
+    frequency_f = np.linspace(f_center - s * fsr, f_center + s * fsr, len_w)
+
+    Hi = tunable_mzi_in(theta_i)
+    Hp = phase_shifter_matrix(phi_t, phi_b)
+    H1 = Hi @ Hp
+    H3 = tunable_mzi_out(theta_o)
+
+    target_spectrum = create_reference_box_filter(
+        frequency_array=frequency_f,
+        center_freq=f_center,
+        fsr=fsr,
+        bandwidth=50e9,
+        passband_level_db=0,
+        stopband_level_db=-40,
+    )
+
+    total_params = n_ku + m_kl
+    bounds = [(0, 1)] * total_params
+
+    args = (target_spectrum, frequency_f, t, w_range, H1, H3, n_ku, m_kl)
+
+    result = optimize_params_sgd(bounds, args)
+    best_params = result.x
+    final_spectrum = optical_simulation(best_params, t, w_range, H1, H3, n_ku, m_kl)
+
+    print("最优参数:")
+    for i in range(n_ku):
+        print(f"  ku{i+1} = {best_params[i]:.4f}")
+    for i in range(m_kl):
+        print(f"  kl{i+1} = {best_params[n_ku + i]:.4f}")
+
+    import matplotlib.pyplot as plt
+
+    plt.figure()
+    plt.plot(
+        frequency_f,
+        target_spectrum,
+        label="Ideal Reference Box-Filter",
+        linestyle="--",
+        linewidth=2.5,
+        color="red",
+    )
+    plt.plot(frequency_f, final_spectrum, label="Final Spectrum (dB)")
+    plt.xlabel("Frequency (Hz)")
+    plt.ylabel("Magnitude (dB)")
+    plt.title("Target vs Final Spectrum")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plt.show()
+

--- a/opt_sim/__init__.py
+++ b/opt_sim/__init__.py
@@ -9,7 +9,7 @@ from .components import (
 )
 from .reference import create_reference_box_filter
 from .simulation import optical_simulation
-from .optimization import objective_function, optimize_params
+from .optimization import objective_function, optimize_params, optimize_params_sgd
 
 __all__ = [
     "tunable_mzi_in",
@@ -21,5 +21,6 @@ __all__ = [
     "optical_simulation",
     "objective_function",
     "optimize_params",
+    "optimize_params_sgd",
 ]
 

--- a/opt_sim/optimization.py
+++ b/opt_sim/optimization.py
@@ -1,7 +1,17 @@
 """基于差分进化的参数优化算法"""
 
 import numpy as np
-from scipy.optimize import differential_evolution
+from types import SimpleNamespace
+
+try:
+    from scipy.optimize import differential_evolution
+except Exception:  # pragma: no cover - SciPy may be unavailable
+    differential_evolution = None
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch may be unavailable
+    torch = None
 
 from .simulation import optical_simulation
 
@@ -67,3 +77,144 @@ def optimize_params(
         disp=True,
     )
     return result
+
+
+def _ensure_torch():
+    if torch is None:
+        raise ImportError("PyTorch is required for SGD optimization")
+
+
+def mrr_transfer_function_torch(w: "torch.Tensor", t: float, k: "torch.Tensor", phi_offset: float) -> "torch.Tensor":
+    j = 1j
+    numerator = torch.sqrt(1 - k) - t ** 2 * torch.exp(-j * (2 * w + phi_offset))
+    denominator = 1 - t ** 2 * torch.sqrt(1 - k) * torch.exp(-j * (2 * w + phi_offset))
+    return numerator / denominator
+
+
+def delay_line_torch(w: "torch.Tensor", t: float, delay: float, phi_c: float) -> "torch.Tensor":
+    j = 1j
+    return t * torch.exp(-j * w * delay - j * phi_c)
+
+
+def optical_simulation_torch(
+    params: "torch.Tensor",
+    t: float,
+    w_range: np.ndarray,
+    H1: np.ndarray,
+    H3: np.ndarray,
+    n_ku: int,
+    m_kl: int,
+) -> "torch.Tensor":
+    device = params.device
+    dtype_c = torch.complex128
+    w = torch.tensor(w_range, dtype=torch.float64, device=device)
+    H1_t = torch.tensor(H1, dtype=dtype_c, device=device)
+    H3_t = torch.tensor(H3, dtype=dtype_c, device=device)
+
+    ku_params = params[:n_ku]
+    kl_params = params[n_ku:]
+
+    if n_ku > 0:
+        au_list = [mrr_transfer_function_torch(w, t, k, phi_offset=np.pi) for k in ku_params]
+        Au = torch.prod(torch.stack(au_list), dim=0)
+    else:
+        Au = torch.ones_like(w, dtype=dtype_c, device=device)
+
+    if m_kl > 0:
+        al_list = [mrr_transfer_function_torch(w, t, k, phi_offset=np.pi) for k in kl_params]
+        Al_mrr = torch.prod(torch.stack(al_list), dim=0)
+    else:
+        Al_mrr = torch.ones_like(w, dtype=dtype_c, device=device)
+
+    Al = Al_mrr * delay_line_torch(w, t, delay=1.0, phi_c=0.0)
+
+    H2_stack = torch.zeros((w.shape[0], 2, 2), dtype=dtype_c, device=device)
+    H2_stack[:, 0, 0] = Au
+    H2_stack[:, 1, 1] = Al
+
+    H_final = H1_t.unsqueeze(0).matmul(H2_stack).matmul(H3_t.unsqueeze(0))
+    H11 = H_final[:, 0, 0]
+
+    return 20 * torch.log10(torch.abs(H11))
+
+
+def objective_function_torch(
+    params: "torch.Tensor",
+    target_spectrum_db: np.ndarray,
+    frequency_f: np.ndarray,
+    t: float,
+    w_range: np.ndarray,
+    H1: np.ndarray,
+    H3: np.ndarray,
+    n_ku: int,
+    m_kl: int,
+) -> "torch.Tensor":
+    target = torch.tensor(target_spectrum_db, dtype=torch.float64, device=params.device)
+    simulated_db = optical_simulation_torch(params, t, w_range, H1, H3, n_ku, m_kl)
+
+    pb_level = torch.max(target)
+    passband_mask = torch.isclose(target, pb_level, atol=1e-6)
+    stopband_mask = ~passband_mask
+
+    if torch.any(passband_mask):
+        mse_passband = torch.mean((simulated_db[passband_mask] - target[passband_mask]) ** 2)
+    else:
+        mse_passband = torch.tensor(0.0, device=params.device)
+
+    leakage_threshold_db = -22.0
+    excess = simulated_db[stopband_mask] - leakage_threshold_db
+    excess_pos = torch.clamp(excess, min=0.0)
+    barrier = torch.log1p(excess_pos) ** 2
+    penalty_stopband = torch.mean(barrier) if barrier.numel() else torch.tensor(0.0, device=params.device)
+
+    passband_weight = 10.0
+    stopband_weight = 1.0
+    loss = passband_weight * mse_passband + stopband_weight * penalty_stopband
+
+    return loss
+
+
+def optimize_params_sgd(
+    bounds,
+    args,
+    maxiter: int = 300,
+    popsize: int = 20,
+):
+    """使用随机梯度下降优化参数，接口与 :func:`optimize_params` 相同."""
+    _ensure_torch()
+
+    (target_spectrum, frequency_f, t, w_range, H1, H3, n_ku, m_kl) = args
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    params = torch.rand(len(bounds), dtype=torch.float64, device=device, requires_grad=True)
+
+    optimizer = torch.optim.SGD([params], lr=0.1)
+
+    best_loss = float("inf")
+    best_params = params.detach().clone()
+
+    for _ in range(maxiter):
+        optimizer.zero_grad()
+        loss = objective_function_torch(
+            params,
+            target_spectrum,
+            frequency_f,
+            t,
+            w_range,
+            H1,
+            H3,
+            n_ku,
+            m_kl,
+        )
+        loss.backward()
+        optimizer.step()
+
+        with torch.no_grad():
+            for idx, (low, high) in enumerate(bounds):
+                params[idx].clamp_(low, high)
+
+        if loss.item() < best_loss:
+            best_loss = loss.item()
+            best_params = params.detach().clone()
+
+    return SimpleNamespace(x=best_params.cpu().numpy())


### PR DESCRIPTION
## Summary
- add PyTorch-based SGD optimizer in `opt_sim.optimization`
- expose the new optimizer in package exports
- add example script `run_sgd.py` demonstrating gradient optimization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685be4b692a48333b210839f864bdac6