### PR TITLE
Fix simulation baseline and add large-dim tests

### DIFF
--- a/bayes_optimization/bayes_optimizer/simulate/optical_chip.py
+++ b/bayes_optimization/bayes_optimizer/simulate/optical_chip.py
@@ -20,13 +20,21 @@ def _load_data() -> tuple[np.ndarray, np.ndarray]:
 
 
 _WAVELENGTHS, _IDEAL_RESPONSE = _load_data()
+# optimal voltages corresponding to the ideal waveform; by default all ones
+_IDEAL_VOLTAGES: np.ndarray | None = None
 
 
-def set_target_waveform(wavelengths: np.ndarray, response: np.ndarray) -> None:
+def set_target_waveform(
+    wavelengths: np.ndarray,
+    response: np.ndarray,
+    ideal_voltages: np.ndarray | None = None,
+) -> None:
     """Update the target waveform used for optimization."""
-    global _WAVELENGTHS, _IDEAL_RESPONSE
+    global _WAVELENGTHS, _IDEAL_RESPONSE, _IDEAL_VOLTAGES
     _WAVELENGTHS = np.asarray(wavelengths, dtype=float)
     _IDEAL_RESPONSE = np.asarray(response, dtype=float)
+    if ideal_voltages is not None:
+        _IDEAL_VOLTAGES = np.asarray(ideal_voltages, dtype=float)
 
 
 def get_target_waveform() -> tuple[np.ndarray, np.ndarray]:
@@ -38,10 +46,15 @@ def response(volts: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Return simulated spectrum for given voltages."""
     num_channels = len(volts)
     n = len(_IDEAL_RESPONSE)
+    global _IDEAL_VOLTAGES
+    if _IDEAL_VOLTAGES is None or len(_IDEAL_VOLTAGES) != num_channels:
+        _IDEAL_VOLTAGES = np.ones(num_channels)
+
     patterns = np.array(
         [np.sin((i + 1) * np.linspace(0, np.pi, n)) for i in range(num_channels)]
-    )
-    delta = volts @ patterns
+    ) / np.sqrt(num_channels)
+
+    delta = (volts - _IDEAL_VOLTAGES) @ patterns
     # amplify influence of voltages so manual adjustment has visible effect
     simulated = _IDEAL_RESPONSE + 0.15 * delta
     return _WAVELENGTHS.copy(), simulated

--- a/bayes_optimization/tests/test_optimizer.py
+++ b/bayes_optimization/tests/test_optimizer.py
@@ -23,3 +23,15 @@ def test_bo_spsa_converges():
     refined = spsa_refine(res["best_x"], loss_fn, a0=0.5, c0=0.1, steps=50)
     final_loss = loss_fn(refined)
     assert final_loss < 0.02
+
+
+def test_large_channel_optimization():
+    """Optimization should still work with many channels."""
+    num_ch = 32
+    bounds = np.tile([[0.0, 2.0]], (num_ch, 1))
+    start = np.full(num_ch, 1.0)
+    bo = BayesOptimizer(GaussianProcess(), expected_improvement, bounds)
+    res = bo.optimize(start, loss_fn, steps=15)
+    refined = spsa_refine(res["best_x"], loss_fn, a0=0.5, c0=0.1, steps=80)
+    final_loss = loss_fn(refined)
+    assert final_loss < 0.05

--- a/bayes_optimization/tests/test_simulate.py
+++ b/bayes_optimization/tests/test_simulate.py
@@ -11,3 +11,5 @@ def test_simulate_response_shape():
     assert resp.shape == _IDEAL_RESPONSE.shape
     assert w.shape == _IDEAL_RESPONSE.shape
     assert np.all(np.isfinite(resp))
+    # zero voltages should not perfectly match the target waveform
+    assert not np.allclose(resp, _IDEAL_RESPONSE)


### PR DESCRIPTION
## Summary
- fix `optical_chip.response` so zero-voltage no longer yields ideal waveform
- scale channel patterns and allow configurable ideal voltages
- check that zero-voltage differs from target in tests
- add 32‑channel optimization test

## Testing
- `pytest -q`
- `pytest bayes_optimization/tests/test_optimizer.py::test_large_channel_optimization -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffae2fb4483339012a5f19685bcbd