### PR TITLE
Add calibration progress streaming

### DIFF
--- a/bayes_optimization/bayes_optimizer/calibrator.py
+++ b/bayes_optimization/bayes_optimizer/calibrator.py
@@ -8,7 +8,8 @@ import numpy as np
 
 from . import config
 from .hardware import apply, read_spectrum
-from .simulate.optical_chip import get_ideal_voltages
+from .simulate.optical_chip import get_ideal_voltages, get_target_waveform
+from typing import Generator, Dict
 
 
 def measure_jacobian(n_samples: int | None = None) -> np.ndarray:
@@ -33,6 +34,42 @@ def measure_jacobian(n_samples: int | None = None) -> np.ndarray:
         J[:, idx] = (resp_plus - resp_minus) / (2 * delta)
 
     return J
+
+
+def measure_jacobian_stream() -> Generator[Dict[str, np.ndarray], None, None]:
+    """Yield calibration progress for each channel.
+
+    Each yielded dictionary has keys ``step``, ``wavelengths``, ``response``,
+    and ``ideal``. The final yield contains ``done`` and ``matrix`` with the
+    measured Jacobian.
+    """
+    num_channels = config.NUM_CHANNELS
+    base_volts = get_ideal_voltages(num_channels)
+    wavelengths, ideal = get_target_waveform()
+    apply(base_volts)
+    _, base_resp = read_spectrum()
+    num_feat = base_resp.size
+    J = np.zeros((num_feat, num_channels))
+    delta = 1e-2
+
+    for idx in range(num_channels):
+        v_plus = base_volts.copy()
+        v_minus = base_volts.copy()
+        v_plus[idx] += delta
+        v_minus[idx] -= delta
+        apply(v_plus)
+        w_p, resp_plus = read_spectrum()
+        apply(v_minus)
+        _, resp_minus = read_spectrum()
+        J[:, idx] = (resp_plus - resp_minus) / (2 * delta)
+        yield {
+            "step": idx,
+            "wavelengths": w_p,
+            "response": resp_plus,
+            "ideal": ideal,
+        }
+
+    yield {"done": True, "matrix": J}
 
 
 def compress_modes(J: np.ndarray, var_ratio: float = 0.95) -> Tuple[int, np.ndarray]:

--- a/bayes_optimization/bayes_optimizer/calibrator.py
+++ b/bayes_optimization/bayes_optimizer/calibrator.py
@@ -59,6 +59,7 @@ def measure_jacobian_stream() -> Generator[Dict[str, np.ndarray], None, None]:
         v_minus[idx] -= delta
         apply(v_plus)
         w_p, resp_plus = read_spectrum()
+        loss = float(np.mean((resp_plus - ideal) ** 2))
         apply(v_minus)
         _, resp_minus = read_spectrum()
         J[:, idx] = (resp_plus - resp_minus) / (2 * delta)
@@ -67,6 +68,9 @@ def measure_jacobian_stream() -> Generator[Dict[str, np.ndarray], None, None]:
             "wavelengths": w_p,
             "response": resp_plus,
             "ideal": ideal,
+            "base": base_volts[idx],
+            "perturb": v_plus[idx],
+            "loss": loss,
         }
 
     yield {"done": True, "matrix": J}

--- a/bayes_optimization/ui/index.html
+++ b/bayes_optimization/ui/index.html
@@ -67,9 +67,20 @@ document.getElementById('modeSelect').onchange = async (e) => {
 document.getElementById('setChannels').onclick = async () => {
   const n = parseInt(document.getElementById('numChannels').value);
   await fetch('/set_channels', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({num_channels:n})});
-  await fetch('/calibrate', {method:'POST'});
   buildTable(Array(n).fill(0), Array(n).fill(0));
-  refreshStatus();
+  const resEl = document.getElementById('result');
+  resEl.textContent = '标定中...';
+  const es = new EventSource('/calibrate_stream');
+  es.onmessage = (e)=>{
+    const data = JSON.parse(e.data);
+    if(data.step !== undefined){
+      drawChart(data.wavelengths, data.ideal, data.response);
+    }else if(data.done){
+      resEl.textContent = `标定完成, 模态数: ${data.modes}`;
+      es.close();
+      refreshStatus();
+    }
+  };
 };
 
 document.getElementById('uploadWave').onclick = async () => {

--- a/bayes_optimization/ui/index.html
+++ b/bayes_optimization/ui/index.html
@@ -75,8 +75,13 @@ document.getElementById('setChannels').onclick = async () => {
     const data = JSON.parse(e.data);
     if(data.step !== undefined){
       drawChart(data.wavelengths, data.ideal, data.response);
+      resEl.textContent += `电极 ${data.step+1} 标定完成 ` +
+        `基准电压:${data.base.toFixed(3)} ` +
+        `扰动电压:${data.perturb.toFixed(3)} ` +
+        `扰动后损失函数:${data.loss.toFixed(6)}\n`;
     }else if(data.done){
-      resEl.textContent = `标定完成, 模态数: ${data.modes}`;
+      const matStr = data.matrix.map(row=>row.map(v=>v.toFixed(3)).join(', ')).join('\n');
+      resEl.textContent += `灵敏度矩阵:\n${matStr}\n标定完成, 模态数: ${data.modes}`;
       es.close();
       refreshStatus();
     }

--- a/bayes_optimization/ui/server.py
+++ b/bayes_optimization/ui/server.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from pathlib import Path
 import numpy as np
 import sys
@@ -18,6 +18,8 @@ from bayes_optimization.bayes_optimizer import (
     hardware,
 )
 from bayes_optimization.bayes_optimizer import calibrator
+import json
+import time
 from bayes_optimization.bayes_optimizer.simulate import optical_chip
 
 app = FastAPI()
@@ -92,6 +94,33 @@ def run_calibrate():
     n, mat = calibrator.compress_modes(J)
     CALIBRATION = {"modes": n, "matrix": mat.tolist()}
     return {"modes": n}
+
+
+@app.get("/calibrate_stream")
+def run_calibrate_stream():
+    if CURRENT_MODE == "real" and not HARDWARE_CONNECTED:
+        raise HTTPException(status_code=400, detail="hardware not connected")
+
+    def event_generator():
+        for data in calibrator.measure_jacobian_stream():
+            if "step" in data:
+                payload = {
+                    "step": data["step"],
+                    "wavelengths": data["wavelengths"].tolist(),
+                    "response": data["response"].tolist(),
+                    "ideal": data["ideal"].tolist(),
+                }
+                yield "data:" + json.dumps(payload) + "\n\n"
+                time.sleep(0.5)
+            elif "done" in data:
+                J = data["matrix"]
+                n, mat = calibrator.compress_modes(J)
+                global CALIBRATION
+                CALIBRATION = {"modes": n, "matrix": mat.tolist()}
+                payload = {"done": True, "modes": n, "matrix": mat.tolist()}
+                yield "data:" + json.dumps(payload) + "\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
 def loss_fn(volts: np.ndarray) -> float:

--- a/bayes_optimization/ui/server.py
+++ b/bayes_optimization/ui/server.py
@@ -109,6 +109,9 @@ def run_calibrate_stream():
                     "wavelengths": data["wavelengths"].tolist(),
                     "response": data["response"].tolist(),
                     "ideal": data["ideal"].tolist(),
+                    "base": data["base"],
+                    "perturb": data["perturb"],
+                    "loss": data["loss"],
                 }
                 yield "data:" + json.dumps(payload) + "\n\n"
                 time.sleep(0.5)


### PR DESCRIPTION
## Summary
- stream calibration progress in `measure_jacobian_stream`
- add `/calibrate_stream` endpoint and stream events via SSE
- update frontend to show calibration steps live

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a2c79d108333bc66468189d919c5