### PR TITLE
Fix custom waveform upload and restrict to CSV

### DIFF
--- a/bayes_optimization/tests/test_ui.py
+++ b/bayes_optimization/tests/test_ui.py
@@ -84,12 +84,4 @@ def test_excel_waveform_upload():
     buf.seek(0)
 
     r = client.post("/upload_waveform", files={"file": ("test.xlsx", buf.getvalue())})
-    assert r.status_code == 200
-    data = r.json()
-    assert data["points"] == 5
-    assert len(data["wavelengths"]) == 5
-    assert len(data["ideal"]) == 5
-    status = client.get("/status").json()
-    assert status["waveform_source"].endswith("test.xlsx")
-    manual = client.post("/manual", json={"voltages": [0]*config.NUM_CHANNELS}).json()
-    assert manual["ideal"] == data["ideal"]
+    assert r.status_code == 400

--- a/bayes_optimization/ui/index.html
+++ b/bayes_optimization/ui/index.html
@@ -26,9 +26,10 @@
 
 <div class="mb-2">
   <label>上传目标波形:</label>
-  <input type="file" id="waveFile" />
+  <input type="file" id="waveFile" accept=".csv" />
   <button id="uploadWave" class="btn">上传</button>
   <span id="waveInfo" class="ml-2 text-sm text-gray-600"></span>
+  <div class="text-sm text-gray-600">仅支持CSV文件，第一行波长，第二行响应，逗号分隔</div>
 </div>
 
 <table class="table mb-2" id="voltageTable">


### PR DESCRIPTION
## Summary
- limit waveform upload to CSV only and properly handle UTF-8 BOM
- remove Excel file handling and update tests
- update UI to restrict file type and show CSV format notice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cbdbd14483338da1bc6df5a2fe15