### PR TITLE
Fix custom waveform handling

### DIFF
--- a/bayes_optimization/ui/index.html
+++ b/bayes_optimization/ui/index.html
@@ -111,9 +111,11 @@ document.getElementById('uploadWave').onclick = async () => {
 function drawChart(w, ideal, resp){
   const ctx = document.getElementById('chart').getContext("2d");
   if (chart) chart.destroy();
+  const allEqual = w.every(v => v === w[0]);
+  const labels = allEqual ? ideal.map((_, i) => i) : w;
   chart = new Chart(ctx,{
     type:'line',
-    data:{labels:w,datasets:[{label:'理想波形',data:ideal,borderColor:'blue',fill:false},{label:'当前响应',data:resp,borderColor:'red',fill:false}]},
+    data:{labels:labels,datasets:[{label:'理想波形',data:ideal,borderColor:'blue',fill:false},{label:'当前响应',data:resp,borderColor:'red',fill:false}]},
     options:{responsive:true}
   });
 }


### PR DESCRIPTION
## Summary
- ensure manual adjustments update ideal waveform handling via get_target_waveform
- display uploaded waveforms even if wavelength values are constant
- unify waveform retrieval in optimizer

## Testing
- `pytest -q`
- `pytest bayes_optimization/tests/test_ui.py::test_visual_workflow -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cf6b8c908333ad48e639b97c90b3