### PR TITLE
Fix simulation independence from target waveform

### DIFF
--- a/bayes_optimization/bayes_optimizer/simulate/optical_chip.py
+++ b/bayes_optimization/bayes_optimizer/simulate/optical_chip.py
@@ -24,7 +24,10 @@ def _load_data() -> tuple[np.ndarray, np.ndarray]:
     return wavelengths, response
 
 
-_WAVELENGTHS, _IDEAL_RESPONSE = _load_data()
+_BASE_WAVELENGTHS, _BASE_RESPONSE = _load_data()
+# Target waveform user wants to match
+_TARGET_WAVELENGTHS = _BASE_WAVELENGTHS.copy()
+_TARGET_RESPONSE = _BASE_RESPONSE.copy()
 # optimal voltages corresponding to the ideal waveform
 _IDEAL_VOLTAGES: np.ndarray | None = None
 _BASIS: np.ndarray | None = None
@@ -37,9 +40,9 @@ def set_target_waveform(
     ideal_voltages: np.ndarray | None = None,
 ) -> None:
     """Update the target waveform used for optimization."""
-    global _WAVELENGTHS, _IDEAL_RESPONSE, _IDEAL_VOLTAGES
-    _WAVELENGTHS = np.asarray(wavelengths, dtype=float)
-    _IDEAL_RESPONSE = np.asarray(response, dtype=float)
+    global _TARGET_WAVELENGTHS, _TARGET_RESPONSE, _IDEAL_VOLTAGES
+    _TARGET_WAVELENGTHS = np.asarray(wavelengths, dtype=float)
+    _TARGET_RESPONSE = np.asarray(response, dtype=float)
     if ideal_voltages is not None:
         _IDEAL_VOLTAGES = np.asarray(ideal_voltages, dtype=float)
     else:
@@ -48,7 +51,7 @@ def set_target_waveform(
 
 def get_target_waveform() -> tuple[np.ndarray, np.ndarray]:
     """Return current target waveform."""
-    return _WAVELENGTHS, _IDEAL_RESPONSE
+    return _TARGET_WAVELENGTHS, _TARGET_RESPONSE
 
 
 def get_ideal_voltages(num_channels: int) -> np.ndarray:
@@ -62,7 +65,7 @@ def get_ideal_voltages(num_channels: int) -> np.ndarray:
 def response(volts: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Return simulated spectrum for given voltages."""
     num_channels = len(volts)
-    n = len(_IDEAL_RESPONSE)
+    n = len(_BASE_RESPONSE)
     global _BASIS, _MIX
 
     ideal = get_ideal_voltages(num_channels)
@@ -82,5 +85,5 @@ def response(volts: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     delta = (diff @ patterns) / num_channels
 
     # amplify influence of voltages so manual adjustment has visible effect
-    simulated = _IDEAL_RESPONSE + 1.0 * delta
-    return _WAVELENGTHS.copy(), simulated
+    simulated = _BASE_RESPONSE + 1.0 * delta
+    return _BASE_WAVELENGTHS.copy(), simulated

--- a/bayes_optimization/scripts/run_optimization.py
+++ b/bayes_optimization/scripts/run_optimization.py
@@ -9,7 +9,8 @@ from bayes_optimization.bayes_optimizer.simulate import optical_chip
 
 def loss_fn(volts: np.ndarray) -> float:
     _, resp = optical_chip.response(volts)
-    return float(np.mean((resp - optical_chip._IDEAL_RESPONSE) ** 2))
+    _, ideal = optical_chip.get_target_waveform()
+    return float(np.mean((resp - ideal) ** 2))
 
 
 def main():
@@ -37,7 +38,7 @@ def main():
     print(f"[INFO] 最终损失 {final_loss:.6f} @ {refined}")
 
     w, final_resp = optical_chip.response(refined)
-    ideal = optical_chip._IDEAL_RESPONSE
+    _, ideal = optical_chip.get_target_waveform()
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/bayes_optimization/tests/test_calibrator.py
+++ b/bayes_optimization/tests/test_calibrator.py
@@ -5,7 +5,8 @@ from bayes_optimization.bayes_optimizer.calibrator import (
     compress_modes,
 )
 from bayes_optimization.bayes_optimizer.simulate.optical_chip import (
-    _IDEAL_RESPONSE,
+    _BASE_RESPONSE,
+    _TARGET_RESPONSE,
     get_ideal_voltages,
     response,
 )
@@ -13,7 +14,7 @@ from bayes_optimization.bayes_optimizer.simulate.optical_chip import (
 
 def test_measure_jacobian_shape():
     J = measure_jacobian()
-    assert J.shape == (_IDEAL_RESPONSE.size, config.NUM_CHANNELS)
+    assert J.shape == (_BASE_RESPONSE.size, config.NUM_CHANNELS)
     assert np.all(np.isfinite(J))
 
 
@@ -37,5 +38,5 @@ def test_calibration_effect():
     perturbed = base.copy()
     perturbed[0] += 0.01
     _, resp = response(perturbed)
-    loss = float(np.mean((resp - _IDEAL_RESPONSE) ** 2))
+    loss = float(np.mean((resp - _TARGET_RESPONSE) ** 2))
     assert loss > 1e-8

--- a/bayes_optimization/tests/test_optimizer.py
+++ b/bayes_optimization/tests/test_optimizer.py
@@ -5,14 +5,14 @@ from bayes_optimization.bayes_optimizer.acquisition import expected_improvement
 from bayes_optimization.bayes_optimizer.spsa import spsa_refine
 from bayes_optimization.bayes_optimizer.simulate.optical_chip import (
     response,
-    _IDEAL_RESPONSE,
+    _TARGET_RESPONSE,
     get_ideal_voltages,
 )
 
 
 def loss_fn(volts: np.ndarray) -> float:
     _, resp = response(volts)
-    return float(np.mean((resp - _IDEAL_RESPONSE) ** 2))
+    return float(np.mean((resp - _TARGET_RESPONSE) ** 2))
 
 
 def test_bo_spsa_converges():

--- a/bayes_optimization/tests/test_simulate.py
+++ b/bayes_optimization/tests/test_simulate.py
@@ -1,7 +1,8 @@
 import numpy as np
 from bayes_optimization.bayes_optimizer.simulate.optical_chip import (
     response,
-    _IDEAL_RESPONSE,
+    _BASE_RESPONSE,
+    _TARGET_RESPONSE,
     get_ideal_voltages,
 )
 from bayes_optimization.bayes_optimizer import config
@@ -9,11 +10,11 @@ from bayes_optimization.bayes_optimizer import config
 
 def test_simulate_response_shape():
     w, resp = response(np.zeros(config.NUM_CHANNELS))
-    assert resp.shape == _IDEAL_RESPONSE.shape
-    assert w.shape == _IDEAL_RESPONSE.shape
+    assert resp.shape == _BASE_RESPONSE.shape
+    assert w.shape == _BASE_RESPONSE.shape
     assert np.all(np.isfinite(resp))
     # zero voltages should not perfectly match the target waveform
-    assert not np.allclose(resp, _IDEAL_RESPONSE)
+    assert not np.allclose(resp, _TARGET_RESPONSE)
     ideal = get_ideal_voltages(config.NUM_CHANNELS)
     _, resp2 = response(ideal)
-    assert np.allclose(resp2, _IDEAL_RESPONSE)
+    assert np.allclose(resp2, _BASE_RESPONSE)


### PR DESCRIPTION
## Summary
- adjust optical chip simulation to use a fixed base response independent of target waveform
- update optimization script to use target waveform API
- adapt unit tests to new simulation behavior

## Testing
- `pytest -q bayes_optimization/tests/test_simulate.py`
- `pytest -q bayes_optimization/tests/test_calibrator.py`
- `pytest -q bayes_optimization/tests/test_optimizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d4d94168833394d155037ffd79f3