### PR TITLE
Refine mock hardware and simulation modules

### DIFF
--- a/new_bayes_optimization/__init__.py
+++ b/new_bayes_optimization/__init__.py
@@ -1,0 +1,12 @@
+"""Utilities for the revised Bayesian optimisation prototype.
+
+This package contains simulation models and hardware connector stubs used to
+experiment with Bayesian optimisation strategies without access to the full
+production environment.
+"""
+
+from .connector import MockHardware, RealHardware
+from .simulate import get_response
+
+__all__ = ["MockHardware", "RealHardware", "get_response"]
+

--- a/new_bayes_optimization/connector/__init__.py
+++ b/new_bayes_optimization/connector/__init__.py
@@ -1,1 +1,11 @@
-from mock_hardware import MockHardware
+"""Hardware connector abstractions.
+
+This package exposes high level interfaces for both the mocked and the real
+hardware backends used by the optimisation workflow.
+"""
+
+from .mock_hardware import MockHardware
+from .real_hardware import RealHardware
+
+__all__ = ["MockHardware", "RealHardware"]
+

--- a/new_bayes_optimization/connector/mock_hardware.py
+++ b/new_bayes_optimization/connector/mock_hardware.py
@@ -1,26 +1,65 @@
+"""Mock hardware interface used for testing.
+
+This module provides a small utility class that mimics the behaviour of the
+real DAC/OSA hardware pair.  It allows the optimisation pipeline to run in
+environments where no physical devices are available.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
 import numpy as np
-from sympy.physics.units import current
 
 from new_bayes_optimization.simulate import get_response
 
+logger = logging.getLogger(__name__)
+
 
 class MockHardware:
-    def __init__(self, DAC_SIZE, wavelength):
-        self.DAC_SIZE = DAC_SIZE
-        self.current_volts = np.zeros(DAC_SIZE)
-        self.wavelength = wavelength
+    """Simple mock implementation of the hardware interface.
 
-    def apply_voltage(self, new_volts: np.ndarray):
-        self.current_volts = new_volts
-        print(f"电压已更新：{self.current_volts}")
+    Parameters
+    ----------
+    dac_size:
+        Number of voltage channels provided by the DAC.
+    wavelength:
+        Wavelength grid on which the simulated optical response is evaluated.
+    """
 
-    def read_voltage(self):
-        return self.current_volts
+    def __init__(self, dac_size: int, wavelength: Iterable[float]) -> None:
+        self.dac_size = int(dac_size)
+        self.wavelength = np.asarray(wavelength, dtype=float)
+        self._current_volts = np.zeros(self.dac_size, dtype=float)
 
-    def get_simulated_response(self,):
-        return get_response(self.wavelength, self.current_volts)
+    def apply_voltage(self, new_volts: Iterable[float]) -> None:
+        """Update DAC output voltages.
 
-if __name__ == "__main__":
-    hardware = MockHardware(4, np.linspace(0,1,11))
-    hardware.apply_voltage(np.array([1,0,0]))
-    print(hardware.get_simulated_response())
+        Parameters
+        ----------
+        new_volts:
+            Sequence of voltages, one per channel.
+        """
+
+        volts = np.asarray(new_volts, dtype=float)
+        if volts.shape != (self.dac_size,):
+            raise ValueError(
+                f"Expected {self.dac_size} voltage values, got {volts.shape}"
+            )
+        self._current_volts = volts
+        logger.debug("Voltage updated: %s", self._current_volts)
+
+    def read_voltage(self) -> np.ndarray:
+        """Return the most recently applied voltages."""
+
+        return self._current_volts.copy()
+
+    def get_simulated_response(self) -> np.ndarray:
+        """Return the simulated optical response for the current voltages."""
+
+        return get_response(self.wavelength, self._current_volts)
+
+
+__all__ = ["MockHardware"]
+

--- a/new_bayes_optimization/connector/real_hardware.py
+++ b/new_bayes_optimization/connector/real_hardware.py
@@ -1,0 +1,40 @@
+"""Placeholder for real hardware interaction.
+
+The project currently uses :class:`~new_bayes_optimization.connector.MockHardware`
+for all simulations and tests.  This module defines a minimal stub that mirrors
+the public API and makes it clear that the real hardware backend still needs to
+be implemented.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+
+
+class RealHardware:
+    """Interface to the actual DAC/OSA hardware.
+
+    The implementation is intentionally left blank; calling any method will
+    raise :class:`NotImplementedError`.  Replace the stubs with the actual
+    device communication code when integrating with hardware.
+    """
+
+    def __init__(self, dac_size: int, wavelength: Iterable[float]) -> None:
+        self.dac_size = int(dac_size)
+        self.wavelength = np.asarray(wavelength, dtype=float)
+        raise NotImplementedError("Real hardware driver is not implemented")
+
+    def apply_voltage(self, new_volts: Iterable[float]) -> None:  # pragma: no cover - placeholder
+        raise NotImplementedError
+
+    def read_voltage(self) -> np.ndarray:  # pragma: no cover - placeholder
+        raise NotImplementedError
+
+    def get_response(self) -> np.ndarray:  # pragma: no cover - placeholder
+        raise NotImplementedError
+
+
+__all__ = ["RealHardware"]
+

--- a/new_bayes_optimization/simulate/__init__.py
+++ b/new_bayes_optimization/simulate/__init__.py
@@ -1,2 +1,6 @@
+"""Simulation utilities for the mock optical hardware."""
+
 from .model import get_response
+
 __all__ = ["get_response"]
+

--- a/new_bayes_optimization/simulate/model.py
+++ b/new_bayes_optimization/simulate/model.py
@@ -1,21 +1,50 @@
+"""Lightweight optical chip simulation.
+
+The simulation is intentionally simple: the optical response is modelled as a
+linear combination of cosine modes whose amplitudes are controlled by the input
+voltages.  This provides a deterministic environment for testing the Bayesian
+optimisation logic without access to real hardware.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
 import numpy as np
 
-def get_response(wavelength, input_volts):
-    wavelength = np.asarray(wavelength)
-    input_volts = np.asarray(input_volts)
+
+def get_response(wavelength: Iterable[float], input_volts: Iterable[float]) -> np.ndarray:
+    """Compute the simulated optical response.
+
+    Parameters
+    ----------
+    wavelength:
+        Sequence of wavelength samples.
+    input_volts:
+        Control voltages for each mode.
+
+    Returns
+    -------
+    np.ndarray
+        Simulated response at each wavelength.
+    """
+
+    wavelength = np.asarray(wavelength, dtype=float)
+    input_volts = np.asarray(input_volts, dtype=float)
+
     w_min, w_max = wavelength.min(), wavelength.max()
     if w_max == w_min:
         raise ValueError("wavelength 所有元素相同，无法做线性映射。")
 
-    x = (wavelength - w_min) / (w_max - w_min) * (2*np.pi) - np.pi
+    # Map wavelengths to [-pi, pi] for mode computation
+    x = (wavelength - w_min) / (w_max - w_min) * (2 * np.pi) - np.pi
 
+    # Construct cosine series
     i = np.arange(1, input_volts.size + 1, dtype=float)[:, None]
-    S = np.cos(i * x)
-    response = (input_volts[:, None] * S).sum(axis=0)
+    basis = np.cos(i * x)
+    response = (input_volts[:, None] * basis).sum(axis=0)
     return response
 
-if __name__=="__main__":
-    wavelengths = np.linspace(0, 1, 11)
-    volts = np.array([1,0,0])
-    resp = response_on_wavelength(wavelengths, volts)
-    print(resp)
+
+__all__ = ["get_response"]
+

--- a/tests/test_mock_hardware.py
+++ b/tests/test_mock_hardware.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from new_bayes_optimization.connector import MockHardware
+from new_bayes_optimization.simulate import get_response
+
+
+def test_get_response_shape_and_linearity():
+    wavelengths = np.linspace(0.0, 1.0, 10)
+    volts1 = np.array([1.0, 0.0, 0.0])
+    volts2 = np.array([0.0, 1.0, 0.0])
+
+    resp1 = get_response(wavelengths, volts1)
+    resp2 = get_response(wavelengths, volts2)
+    resp12 = get_response(wavelengths, volts1 + volts2)
+
+    assert resp1.shape == wavelengths.shape
+    # Linearity check
+    np.testing.assert_allclose(resp1 + resp2, resp12)
+
+
+def test_mock_hardware_interface():
+    wavelengths = np.linspace(0.0, 1.0, 20)
+    hardware = MockHardware(3, wavelengths)
+    volts = np.array([0.1, 0.2, 0.3])
+
+    hardware.apply_voltage(volts)
+    np.testing.assert_allclose(hardware.read_voltage(), volts)
+    resp = hardware.get_simulated_response()
+    assert resp.shape == wavelengths.shape
+


### PR DESCRIPTION
## Summary
- add package structure and exports for new_bayes_optimization
- document mock and real hardware connectors
- rewrite optical chip simulation and provide tests

## Testing
- `pytest -q` *(fails: bayes_optimization tests assert high loss)*
- `pytest tests/test_mock_hardware.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16b194dcc8333b3282e74ff2c3694