### PR TITLE
Add per-electrode noise to optical chip simulation

### DIFF
--- a/new_bayes_optimization/simulate/model.py
+++ b/new_bayes_optimization/simulate/model.py
@@ -8,12 +8,17 @@ optimisation logic without access to real hardware.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Optional
 
 import numpy as np
 
 
-def get_response(wavelength: Iterable[float], input_volts: Iterable[float]) -> np.ndarray:
+def get_response(
+    wavelength: Iterable[float],
+    input_volts: Iterable[float],
+    noise_std: Optional[Iterable[float]] = None,
+    rng: Optional[np.random.Generator] = None,
+) -> np.ndarray:
     """Compute the simulated optical response.
 
     Parameters
@@ -22,6 +27,14 @@ def get_response(wavelength: Iterable[float], input_volts: Iterable[float]) -> n
         Sequence of wavelength samples.
     input_volts:
         Control voltages for each mode.
+    noise_std:
+        Optional standard deviation of Gaussian noise applied independently to
+        each voltage.  Can be a scalar or sequence matching ``input_volts``.
+        If ``None`` (default) no noise is added.
+    rng:
+        Optional ``numpy.random.Generator`` instance used to draw the noise.
+        If omitted, ``np.random.default_rng()`` is used when ``noise_std`` is
+        provided.
 
     Returns
     -------
@@ -31,6 +44,19 @@ def get_response(wavelength: Iterable[float], input_volts: Iterable[float]) -> n
 
     wavelength = np.asarray(wavelength, dtype=float)
     input_volts = np.asarray(input_volts, dtype=float)
+
+    if noise_std is not None:
+        noise_std = np.asarray(noise_std, dtype=float)
+        try:
+            noise_std = np.broadcast_to(noise_std, input_volts.shape)
+        except ValueError as exc:
+            raise ValueError(
+                "noise_std must be broadcastable to the shape of input_volts"
+            ) from exc
+        if rng is None:
+            rng = np.random.default_rng()
+        noise = rng.normal(0.0, noise_std, size=input_volts.shape)
+        input_volts = input_volts + noise
 
     w_min, w_max = wavelength.min(), wavelength.max()
     if w_max == w_min:

--- a/tests/test_simulate_noise.py
+++ b/tests/test_simulate_noise.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from new_bayes_optimization.simulate import get_response
+
+
+def test_zero_noise_equals_deterministic():
+    wavelengths = np.linspace(0.0, 1.0, 10)
+    volts = np.array([0.5, -0.2, 0.3])
+    resp_det = get_response(wavelengths, volts)
+    resp_zero = get_response(wavelengths, volts, noise_std=0.0, rng=np.random.default_rng(0))
+    np.testing.assert_allclose(resp_det, resp_zero)
+
+
+def test_reproducible_with_seed():
+    wavelengths = np.linspace(0.0, 1.0, 20)
+    volts = np.array([0.1, 0.2, 0.3])
+    noise = np.array([0.01, 0.02, 0.03])
+    rng1 = np.random.default_rng(42)
+    rng2 = np.random.default_rng(42)
+    resp1 = get_response(wavelengths, volts, noise_std=noise, rng=rng1)
+    resp2 = get_response(wavelengths, volts, noise_std=noise, rng=rng2)
+    np.testing.assert_allclose(resp1, resp2)
+
+
+def test_noise_statistics_match_expectation():
+    wavelengths = np.linspace(0.0, 1.0, 50)
+    volts = np.zeros(3)
+    noise_std = np.array([0.1, 0.2, 0.3])
+    rng = np.random.default_rng(0)
+    samples = np.array([
+        get_response(wavelengths, volts, noise_std=noise_std, rng=rng)
+        for _ in range(1000)
+    ])
+    sample_mean = samples.mean(axis=0)
+    sample_var = samples.var(axis=0)
+
+    # Analytic variance of the linear combination of modes
+    w_min, w_max = wavelengths.min(), wavelengths.max()
+    x = (wavelengths - w_min) / (w_max - w_min) * (2 * np.pi) - np.pi
+    i = np.arange(1, len(volts) + 1)[:, None]
+    basis = np.cos(i * x)
+    expected_var = ((noise_std[:, None] ** 2) * (basis ** 2)).sum(axis=0)
+
+    np.testing.assert_allclose(sample_mean, 0.0, atol=5e-2)
+    np.testing.assert_allclose(sample_var, expected_var, rtol=0.2)


### PR DESCRIPTION
## Summary
- allow `get_response` to inject Gaussian noise per electrode with optional RNG
- add tests verifying reproducibility, zero-noise behaviour, and expected statistics

## Testing
- `pytest tests/test_simulate_noise.py -q`
- `pytest -q` *(fails: test_bo_spsa_converges, test_large_channel_optimization)*

------
https://chatgpt.com/codex/tasks/task_e_68a1782fca1c833383afe301135ae705