### PR TITLE
feat: add hardware objective wrapper

### DIFF
--- a/new_bayes_optimization/connector/mock_hardware.py
+++ b/new_bayes_optimization/connector/mock_hardware.py
@@ -8,7 +8,7 @@ environments where no physical devices are available.
 from __future__ import annotations
 
 import logging
-from typing import Iterable
+from typing import Iterable, Optional
 
 import numpy as np
 
@@ -28,10 +28,37 @@ class MockHardware:
         Wavelength grid on which the simulated optical response is evaluated.
     """
 
-    def __init__(self, dac_size: int, wavelength: Iterable[float]) -> None:
+    def __init__(
+        self,
+        dac_size: int,
+        wavelength: Iterable[float],
+        noise_std: Optional[Iterable[float] | float] = None,
+        rng: Optional[np.random.Generator] = None,
+    ) -> None:
+        """Create a mock hardware instance.
+
+        Parameters
+        ----------
+        dac_size:
+            Number of DAC channels.
+        wavelength:
+            Sampling grid for the simulated optical response.
+        noise_std:
+            Optional standard deviation of Gaussian noise added to each
+            voltage channel before computing the response.  Can be a scalar or
+            broadcastable sequence.  ``None`` disables noise.
+        rng:
+            Optional random number generator used when ``noise_std`` is not
+            ``None``.  If omitted, a default generator is created.
+        """
+
         self.dac_size = int(dac_size)
         self.wavelength = np.asarray(wavelength, dtype=float)
         self._current_volts = np.zeros(self.dac_size, dtype=float)
+        self.noise_std = noise_std
+        if noise_std is not None and rng is None:
+            rng = np.random.default_rng()
+        self._rng = rng
 
     def apply_voltage(self, new_volts: Iterable[float]) -> None:
         """Update DAC output voltages.
@@ -58,7 +85,12 @@ class MockHardware:
     def get_simulated_response(self) -> np.ndarray:
         """Return the simulated optical response for the current voltages."""
 
-        return get_response(self.wavelength, self._current_volts)
+        return get_response(
+            self.wavelength,
+            self._current_volts,
+            noise_std=self.noise_std,
+            rng=self._rng,
+        )
 
 
 __all__ = ["MockHardware"]

--- a/tests/test_mock_hardware.py
+++ b/tests/test_mock_hardware.py
@@ -20,11 +20,22 @@ def test_get_response_shape_and_linearity():
 
 def test_mock_hardware_interface():
     wavelengths = np.linspace(0.0, 1.0, 20)
-    hardware = MockHardware(3, wavelengths)
+    hardware = MockHardware(3, wavelengths, noise_std=0.0)
     volts = np.array([0.1, 0.2, 0.3])
 
     hardware.apply_voltage(volts)
     np.testing.assert_allclose(hardware.read_voltage(), volts)
     resp = hardware.get_simulated_response()
     assert resp.shape == wavelengths.shape
+
+
+def test_mock_hardware_noise_injection():
+    wavelengths = np.linspace(0.0, 1.0, 20)
+    volts = np.array([0.1, 0.2, 0.3])
+    hardware = MockHardware(3, wavelengths, noise_std=0.1, rng=np.random.default_rng(0))
+    hardware.apply_voltage(volts)
+    resp1 = hardware.get_simulated_response()
+    resp2 = hardware.get_simulated_response()
+    # successive reads should differ due to injected noise
+    assert not np.allclose(resp1, resp2)
 

--- a/tests/test_objective.py
+++ b/tests/test_objective.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+from new_bayes_optimization.connector import MockHardware
+from new_bayes_optimization.optimizer.objective import create_hardware_objective
+from new_bayes_optimization.simulate import get_response
+
+
+def _save_two_row_csv(path, x, y):
+    data = np.vstack([x, y])
+    np.savetxt(path, data, delimiter=",")
+
+
+def test_hardware_objective_matches_target(tmp_path):
+    wavelengths = np.linspace(0.0, 1.0, 50)
+    volts = np.array([0.5, -0.3])
+    target = get_response(wavelengths, volts)
+    csv_path = tmp_path / "ideal.csv"
+    _save_two_row_csv(csv_path, wavelengths, target)
+
+    hw = MockHardware(
+        dac_size=volts.size,
+        wavelength=wavelengths,
+        noise_std=0.0,
+        rng=np.random.default_rng(0),
+    )
+    obj = create_hardware_objective(hw, csv_path, M=50)
+
+    loss, diag = obj(volts)
+    assert loss < 1e-5
+    assert abs(diag["delta_nm"]) < 1e-2
+
+    worse_loss, _ = obj(volts + 0.1)
+    assert worse_loss > loss
+
+
+def test_hardware_objective_with_noise(tmp_path):
+    wavelengths = np.linspace(0.0, 1.0, 50)
+    volts = np.array([0.5, -0.3])
+    target = get_response(wavelengths, volts)
+    csv_path = tmp_path / "ideal.csv"
+    _save_two_row_csv(csv_path, wavelengths, target)
+
+    hw = MockHardware(
+        dac_size=volts.size,
+        wavelength=wavelengths,
+        noise_std=0.05,
+        rng=np.random.default_rng(0),
+    )
+    obj = create_hardware_objective(hw, csv_path, M=50)
+
+    loss1, _ = obj(volts)
+    loss2, _ = obj(volts)
+    assert loss1 != loss2


### PR DESCRIPTION
## Summary
- extend curve objective with hardware wrapper to evaluate waveforms directly from MockHardware
- enable noise simulation in MockHardware and verify objective behaviour under noise

## Testing
- `pytest tests/test_objective.py tests/test_mock_hardware.py tests/test_components.py tests/test_simulate_noise.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a185692dbc8333848587765279682a